### PR TITLE
Fix docs update bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -207,9 +207,10 @@ Examples:
 ### Postpone a task's date : `snooze` ----- Max
 
 Postpones your task's date by a specified number of days so that you have the flexibility
-to push back the deadline of task when necessary. Calendar will be reset.
+to push back the deadline of task when necessary.
 
 Format: `snooze INDEX [DAYS]`
+
 * Edits the task at the specified `INDEX`. The index refers to the index number shown in the displayed list.
  The index **must be a positive integer** e.g 1, 2, 3, …​
 * DAYS must be a positive integer and at most 365 (1 year).
@@ -224,10 +225,9 @@ Examples:
 
 
 Sets a task's status to 'done' so that you can track the tasks that have completed easily.
- Calendar will be reset.
-
 
 Format: `done INDEX`
+
 * Sets the task at the specified `INDEX` to be done. The index refers to the index number shown in the displayed list.
 * If the task's status is already 'done', the planner will give a warning.
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,7 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "Index should be positive and within the range of"
             + " the list.";
-    public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!\n";
+    public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d task(s) listed!\n";
     public static final String MESSAGE_CALENDAR_SHOWING_CURRENT_MONTH = "Calendar is now showing this month.\n";
     public static final String MESSAGE_INVALID_PREAMBLE = "Your command might have spaces in your command word, "
             + "as there is an invalid preamble detected before the first valid prefix.";

--- a/src/main/java/seedu/address/logic/commands/DoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DoneCommand.java
@@ -31,7 +31,7 @@ public class DoneCommand extends Command {
     public static final String MESSAGE_INDEX_OUT_OF_RANGE = "Please check that your index is positive and within the"
             + " range of the list.";
 
-    public static final String MESSAGE_DONE_TASK_SUCCESS = "Task: %1$s marked as done.";
+    public static final String MESSAGE_DONE_TASK_SUCCESS = "Task successfully marked as done. \n\n Task: %1$s ";
 
     public static final String MESSAGE_TASK_ALREADY_DONE = "Task: %1$s is already done. Did you type the wrong index?";
 
@@ -83,8 +83,6 @@ public class DoneCommand extends Command {
         taskStatusSetToDone = setTaskStatusAsDone(taskToSetAsDone);
 
         model.setTask(taskToSetAsDone, taskStatusSetToDone);
-        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
-        model.resetCalendarDate();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/DoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DoneCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/seedu/address/logic/commands/SnoozeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SnoozeCommand.java
@@ -100,8 +100,6 @@ public class SnoozeCommand extends Command {
         Task snoozedTask = updateTaskWithNewDate(taskToSnooze);
 
         model.setTask(taskToSnooze, snoozedTask);
-        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
-        model.resetCalendarDate();
     }
 
     private Task updateTaskWithNewDate(Task taskToSnooze) {

--- a/src/main/java/seedu/address/logic/commands/SnoozeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SnoozeCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/seedu/address/model/task/attributes/Date.java
+++ b/src/main/java/seedu/address/model/task/attributes/Date.java
@@ -42,7 +42,9 @@ public class Date implements Attribute {
     public Date(String date) {
         checkArgument(isValidDate(date), MESSAGE_CONSTRAINTS);
         value = parseDate(date);
-        isValidDate = ValidDateFormatter.isValid(date);
+        if (!date.equals("")) {
+            isValidDate = ValidDateFormatter.isValid(date);
+        }
 
         if (date.length() != 0) {
             LocalDate today = LocalDate.now();


### PR DESCRIPTION
Fix Bug in Date where only a non-empty string date
field can be used with valid date formatter

Fix Bug in Snooze and Done command resetting to
main list by removing the predicate to show all
tasks in update model

Update UG to be consistent with behavior

Fix Bug where done command success message
sticking to the end of tag 

Fix checkstyle error by removing unused imports